### PR TITLE
Skip notification request if we actually are watching nothing

### DIFF
--- a/apollo_client.go
+++ b/apollo_client.go
@@ -57,6 +57,9 @@ func (c *apolloClient) Apply(opts ...ApolloClientOption) {
 
 func (c *apolloClient) Notifications(configServerURL, appID, cluster string, notifications []Notification) (status int, result []Notification, err error) {
 	configServerURL = normalizeURL(configServerURL)
+	if notifications == nil || len(notifications) == 0 {
+		return 0, []Notification{}, nil
+	}
 	requestURI := fmt.Sprintf("/notifications/v2?appId=%s&cluster=%s&notifications=%s",
 		url.QueryEscape(appID),
 		url.QueryEscape(cluster),

--- a/apollo_client.go
+++ b/apollo_client.go
@@ -56,10 +56,10 @@ func (c *apolloClient) Apply(opts ...ApolloClientOption) {
 }
 
 func (c *apolloClient) Notifications(configServerURL, appID, cluster string, notifications []Notification) (status int, result []Notification, err error) {
-	configServerURL = normalizeURL(configServerURL)
-	if notifications == nil || len(notifications) == 0 {
+	if len(notifications) == 0 {
 		return 0, []Notification{}, nil
 	}
+	configServerURL = normalizeURL(configServerURL)
 	requestURI := fmt.Sprintf("/notifications/v2?appId=%s&cluster=%s&notifications=%s",
 		url.QueryEscape(appID),
 		url.QueryEscape(cluster),


### PR DESCRIPTION
If no namespace should be watched, we can skip long polling request to reduce potential pressure imposed on the config server.

As is described in the following code,

https://github.com/ctripcorp/apollo/blob/master/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2.java#L92-L98

Apollo will just throw an exception if Notification array presented by `notificationsAsString` is empty.