### PR TITLE
升级依赖Viper 1.8.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,9 @@ module github.com/shima-park/agollo
 go 1.13
 
 require (
-	github.com/magiconair/properties v1.8.1
-	github.com/pelletier/go-toml v1.4.0 // indirect
-	github.com/spf13/viper v1.4.0
-	github.com/stretchr/testify v1.6.1
-	github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+	github.com/bketelsen/crypt v0.0.4
+	github.com/magiconair/properties v1.8.5
+	github.com/spf13/viper v1.8.1
+	github.com/stretchr/testify v1.7.0
 	gopkg.in/go-playground/assert.v1 v1.2.1
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/yoyofxteam/agollo
+module github.com/shima-park/agollo
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/shima-park/agollo
+module github.com/yoyofxteam/agollo
 
 go 1.13
 

--- a/viper-remote/remote.go
+++ b/viper-remote/remote.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"sync"
 
+	crypt "github.com/bketelsen/crypt/config"
 	"github.com/shima-park/agollo"
 	"github.com/spf13/viper"
-	crypt "github.com/xordataexchange/crypt/config"
 )
 
 var (
@@ -87,7 +87,7 @@ func newAgollo(appid, endpoint string, opts []agollo.Option) (agollo.Agollo, err
 		// 监听并同步apollo配置
 		ag.Start()
 
-		agolloMap.Store(endpoint + "/" + appid, ag)
+		agolloMap.Store(endpoint+"/"+appid, ag)
 
 		return ag, nil
 	}


### PR DESCRIPTION
升级Viper 1.8.1 引用依赖 etcd client v3 3.5.0 解决模板化问题， 如不升级此版本可能会与使用 grpc和 etcd的项目冲突。