### PR TITLE
扩展viper,简化apollo配置,实现远程配置变更通知

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,13 +309,6 @@ func main(){
 }
 ```
 
-如果碰到panic: codecgen version mismatch: current: 8, need 10这种错误，详情请见[issue](https://github.com/shima-park/agollo/issues/14)
-解决办法是将etcd升级到3.3.13:
-```
-// 使用go module管理依赖包，使用如下命令更新到此版本，或者更高版本
-go get github.com/coreos/etcd@v3.3.13+incompatible
-```
-
 ### viper配置同步
 基于轮训的配置同步
 ```

--- a/examples/viper/main.go
+++ b/examples/viper/main.go
@@ -67,3 +67,26 @@ func main() {
 	}
 
 }
+
+func extenderTestWatchAndNotify() {
+	remoteProvider, _ := remote.NewApolloProvider(remote.ApolloConfig{
+		Endpoint: "localhost:8080",
+		AppID: "SampleApp",
+		ConfigType: "prop",
+		Namespace: "application",
+	})
+
+	v := remoteProvider.GetViper()
+	// sync read remote config
+	_ = v.ReadRemoteConfig()
+	fmt.Println("app.AllSettings:", v.AllSettings())
+
+	respChan := remoteProvider.WatchRemoteConfigOnChannel()
+	go func(rc <-chan bool) {
+		for {
+			<-rc
+			// on changed and notify
+			fmt.Println("app.AllSettings:", v.AllSettings())
+		}
+	}(respChan)
+}

--- a/viper-remote/remote_extender.go
+++ b/viper-remote/remote_extender.go
@@ -1,0 +1,80 @@
+package remote
+
+import (
+	"bytes"
+	"github.com/spf13/viper"
+)
+type Extender struct {
+	// provider information
+	provider      string
+	endpoint      string
+	path          string
+	secretKeyring string
+	// viper
+	viper 		  *viper.Viper
+}
+
+func (rp *Extender) Provider() string {
+	return rp.provider
+}
+
+func (rp *Extender) Endpoint() string {
+	return rp.endpoint
+}
+
+func (rp *Extender) Path() string {
+	return rp.path
+}
+
+func (rp *Extender) SecretKeyring() string {
+	return rp.secretKeyring
+}
+
+// ApolloConfig Apollo Config
+type ApolloConfig struct {
+	// apollo endpoint or url
+	Endpoint   string
+	// apollo appid
+	AppID      string
+	// config file type ,such as prop or yaml
+	ConfigType string
+	// apollo namespace
+	Namespace  string
+}
+
+// NewApolloProvider new apollo viper remote provider by apollo config
+func NewApolloProvider(config ApolloConfig)  (*Extender,error) {
+	return newApolloProvider(config.Endpoint,config.AppID,config.ConfigType,config.Namespace)
+}
+
+// NewApolloProvider new apollo viper remote provider
+func newApolloProvider(endpoint string,appid string,configType string,namespace string) (*Extender,error) {
+	SetAppID(appid)
+	v := viper.New()
+	v.SetConfigType(configType)
+	err := v.AddRemoteProvider("apollo", endpoint, namespace)
+	return &Extender{provider: "apollo", endpoint: endpoint, path: namespace, secretKeyring: "" , viper: v},err
+}
+
+// GetViper get viper instance
+func (rp *Extender) GetViper() *viper.Viper {
+	return rp.viper
+}
+
+// WatchRemoteConfigOnChannel watch remote config changed on notify
+func (rp *Extender) WatchRemoteConfigOnChannel() <-chan bool {
+	updater := make(chan bool)
+	respChan, _ := viper.RemoteConfig.WatchChannel(rp)
+	go func(rc <-chan *viper.RemoteResponse) {
+		for {
+			b := <-rc
+			reader := bytes.NewReader(b.Value)
+			_ = rp.viper.ReadConfig(reader)
+			// configuration on changed
+			updater <- true
+		}
+	}(respChan)
+
+	return updater
+}
+


### PR DESCRIPTION
特性:
* Add apollo remote provider by viper , that implementation  watch remote changed and notify.
使用:
```go
	remoteProvider, _ := remote.NewApolloProvider(remote.ApolloConfig{
		Endpoint: "localhost:8080",
		AppID: "SampleApp",
		ConfigType: "prop",
		Namespace: "application",
	})

	v := remoteProvider.GetViper()
	// sync read remote config
	_ = v.ReadRemoteConfig()
	fmt.Println("app.AllSettings:", v.AllSettings())

        // apollo 远程配置变更监听
	respChan := remoteProvider.WatchRemoteConfigOnChannel()
	go func(rc <-chan bool) {
		for {
			<-rc
			// on changed and notify
			fmt.Println("app.AllSettings:", v.AllSettings())
		}
	}(respChan)
```

