### PR TITLE
[feat]: Fix mulit slb node update notification ID bug & Support heart beat

### DIFF
--- a/options.go
+++ b/options.go
@@ -13,6 +13,8 @@ var (
 	defaultFailTolerantOnBackupExists = false
 	defaultEnableSLB                  = false
 	defaultLongPollInterval           = 1 * time.Second
+	defaultEnableHeartBeat            = false
+	defaultHeartBeatInterval          = 300 * time.Second
 )
 
 type Options struct {
@@ -30,6 +32,8 @@ type Options struct {
 	EnableSLB                  bool                 // 启用ConfigServer负载均衡
 	RefreshIntervalInSecond    time.Duration        // ConfigServer刷新间隔
 	ClientOptions              []ApolloClientOption // 设置apollo HTTP api的配置项
+	EnableHeartBeat            bool                 // 是否允许兜底检查，默认：false
+	HeartBeatInterval          time.Duration        // 兜底检查间隔时间，默认：300s
 }
 
 func newOptions(configServerURL, appID string, opts ...Option) (Options, error) {
@@ -43,6 +47,8 @@ func newOptions(configServerURL, appID string, opts ...Option) (Options, error) 
 		BackupFile:                 defaultBackupFile,
 		FailTolerantOnBackupExists: defaultFailTolerantOnBackupExists,
 		EnableSLB:                  defaultEnableSLB,
+		EnableHeartBeat:            defaultEnableHeartBeat,
+		HeartBeatInterval:          defaultHeartBeatInterval,
 	}
 	for _, opt := range opts {
 		opt(&options)
@@ -144,6 +150,18 @@ func AutoFetchOnCacheMiss() Option {
 func LongPollerInterval(i time.Duration) Option {
 	return func(o *Options) {
 		o.LongPollerInterval = i
+	}
+}
+
+func EnableHeartBeat(b bool) Option {
+	return func(o *Options) {
+		o.EnableHeartBeat = b
+	}
+}
+
+func HeartBeatInterval(i time.Duration) Option {
+	return func(o *Options) {
+		o.HeartBeatInterval = i
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -26,6 +26,8 @@ func TestOptions(t *testing.T) {
 				assert.Equal(t, defaultBackupFile, opts.BackupFile)
 				assert.Equal(t, defaultFailTolerantOnBackupExists, opts.FailTolerantOnBackupExists)
 				assert.Equal(t, defaultEnableSLB, opts.EnableSLB)
+				assert.Equal(t, defaultEnableHeartBeat, opts.EnableHeartBeat)
+				assert.Equal(t, defaultHeartBeatInterval, opts.HeartBeatInterval)
 				assert.NotNil(t, opts.Logger)
 				assert.NotNil(t, opts.ApolloClient)
 				assert.NotNil(t, opts.Balancer)
@@ -50,6 +52,8 @@ func TestOptions(t *testing.T) {
 				BackupFile("test_backup"),
 				FailTolerantOnBackupExists(),
 				AccessKey("test_access_key"),
+				EnableHeartBeat(true),
+				HeartBeatInterval(time.Second * 120),
 			},
 			func(opts Options) {
 				assert.Equal(t, "test_cluster", opts.Cluster)
@@ -66,6 +70,8 @@ func TestOptions(t *testing.T) {
 				ac := &apolloClient{}
 				ac.Apply(opts.ClientOptions...)
 				assert.Equal(t, "test_access_key", ac.AccessKey)
+				assert.Equal(t, true, opts.EnableHeartBeat)
+				assert.Equal(t, time.Second*120, opts.HeartBeatInterval)
 			},
 		},
 		{


### PR DESCRIPTION
1. slb 后有多节点时，多个扫描可能不同步，会出现 a 节点（已扫描更新）触发了 Notification Update，但是 getNamespace 打到 b 节点（尚未扫描更新），导致更新了 Notification ID 却没有读到新配置。
2. 支持开启兜底检查机制。
